### PR TITLE
Fix/11 - Changing the "duplicate email" field to an array.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,7 @@
 ## [[2.0.5]](https://github.com/lightspeeddevelopment/cf-zoho/releases/tag/2.0.5) - Unreleased
 
 ### Fixed
-- [#11](https://github.com/lightspeeddevelopment/cf-zoho/issues/11) The Zoho request failing while workflow mode is enabled, and the duplicate checks is not.
-
+- [#11](https://github.com/lightspeeddevelopment/cf-zoho/issues/11) Changed the "duplicate email" field to an array instead of a string.
 
 ## [[2.0.4]](https://github.com/lightspeeddevelopment/cf-zoho/releases/tag/2.0.4) - 2020-03-30
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 # Change log
 
+## [[2.0.5]](https://github.com/lightspeeddevelopment/cf-zoho/releases/tag/2.0.5) - Unreleased
+
+### Fixed
+- [#11](https://github.com/lightspeeddevelopment/cf-zoho/issues/11) The Zoho request failing while workflow mode is enabled, and the duplicate checks is not.
+
 
 ## [[2.0.4]](https://github.com/lightspeeddevelopment/cf-zoho/releases/tag/2.0.4) - 2020-03-30
 

--- a/includes/class-cf-processors.php
+++ b/includes/class-cf-processors.php
@@ -321,7 +321,9 @@ class CF_Processors {
 		}
 
 		if ( ! empty( $this->config['_workflow_mode'] ) ) {
-			$trigger[] = 'workflow';
+			$trigger[]                        = 'workflow';
+			$path                            .= '/upsert';
+			$object['duplicate_check_fields'] = 'Email';
 		}
 
 		$body = [

--- a/includes/class-cf-processors.php
+++ b/includes/class-cf-processors.php
@@ -598,11 +598,9 @@ class CF_Processors {
 		$zoho_field = $this->is_zoho_form_field( $this->config[ $key ] );
 		if ( false !== $zoho_field ) {
 			$new_values = array();
-			if ( isset( $_POST[ $zoho_field ] ) ) { // phpcs:ignore
-				$values = explode( ',', $_POST[ $zoho_field ] ); // phpcs:ignore
+			if ( isset( $_POST[ $zoho_field ] ) ) { // @codingStandardsIgnoreLine
+				$values = explode( ',', $_POST[ $zoho_field ] ); // @codingStandardsIgnoreLine
 
-			//if ( isset( $value ) ) {
-				//$values = explode( ',', $value );
 				if ( ! is_array( $values ) ) {
 					$values = array( $values );
 				}

--- a/includes/class-cf-processors.php
+++ b/includes/class-cf-processors.php
@@ -311,7 +311,7 @@ class CF_Processors {
 
 		if ( isset( $this->config['_allow_duplicates'] ) && 'update' === $this->config['_allow_duplicates'] ) {
 			$path                            .= '/upsert';
-			$object['duplicate_check_fields'] = 'Email';
+			$object['duplicate_check_fields'] = array( 'Email' );
 		}
 
 		$trigger = [];
@@ -321,9 +321,7 @@ class CF_Processors {
 		}
 
 		if ( ! empty( $this->config['_workflow_mode'] ) ) {
-			$trigger[]                        = 'workflow';
-			$path                            .= '/upsert';
-			$object['duplicate_check_fields'] = 'Email';
+			$trigger[] = 'workflow';
 		}
 
 		$body = [

--- a/includes/class-cf-processors.php
+++ b/includes/class-cf-processors.php
@@ -600,8 +600,8 @@ class CF_Processors {
 		$zoho_field = $this->is_zoho_form_field( $this->config[ $key ] );
 		if ( false !== $zoho_field ) {
 			$new_values = array();
-			if ( isset( $_POST[ $zoho_field ] ) ) {
-				$values = explode( ',', $_POST[ $zoho_field ] );
+			if ( isset( $_POST[ $zoho_field ] ) ) { // phpcs:ignore
+				$values = explode( ',', $_POST[ $zoho_field ] ); // phpcs:ignore
 
 			//if ( isset( $value ) ) {
 				//$values = explode( ',', $value );

--- a/lsx-cf-zoho.php
+++ b/lsx-cf-zoho.php
@@ -6,7 +6,7 @@
  * Plugin Name:       LSX Zoho CRM Addon for Caldera Forms
  * Plugin URI:        https://github.com/lightspeeddevelopment/cf-zoho
  * Description:       Caldera Forms is one of a kind WordPress form builder. With its user friendly drag and drop interface, it’s simple to create forms for your WordPress site that look awesome on any device. Caldera also comes with a range of add-ons, like integration with the Zoho CRM platform, which allows users to automate their day-to-day business activities allowing them to focus on selling without having to worry about digging through data. Use the extension to track your sales activities and gain complete understanding of your sales cycle.
- * Version:           2.0.4
+ * Version:           2.0.5
  * Author:            LightSpeed
  * Author URI:        https://www.lsdev.biz/
  * Contributors       feedmycode, matttrustmytravel
@@ -16,6 +16,7 @@
  */
 
 namespace lsx_cf_zoho;
+
 use lsx_cf_zoho\includes;
 
 // If this file is called directly, abort.
@@ -25,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version.
  */
-define( 'LSX_CFZ_VERSION', '2.0.4' );
+define( 'LSX_CFZ_VERSION', '2.0.5' );
 define( 'LSX_CFZ_ABSPATH', dirname( __FILE__ ) . '/' );
 
 define( 'LSX_CFZ_TEMPLATE_PATH', LSX_CFZ_ABSPATH . 'templates/' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-cf-zoho",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "description": "",
   "main": "gulpfile.js",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -39,3 +39,4 @@ In order for this plugin to work at efficient speeds, Zoho CRM fields and users 
 == Processor Configuration ==
 
 * When setting a "Layout" you will need to include the name and the ID separated by a | symbol.  The name goes first, and then the ID. e.g "Direct|11111111111"
+* When using the "Workflow" mode, the processor will automatically be set to check for duplicate entries, otherwise the request fails.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Caldera Forms, zoho, crm
 Requires at least: 4.8
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 2.0.4
+Stable tag: 2.0.5
 License: GPLv3.0+
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,4 +39,3 @@ In order for this plugin to work at efficient speeds, Zoho CRM fields and users 
 == Processor Configuration ==
 
 * When setting a "Layout" you will need to include the name and the ID separated by a | symbol.  The name goes first, and then the ID. e.g "Direct|11111111111"
-* When using the "Workflow" mode, the processor will automatically be set to check for duplicate entries, otherwise the request fails.


### PR DESCRIPTION
### Description of the Change
The "duplicate email" field was causing errors when using a new email address to sign up.  It would return a Json error.  After reading through the docs some more I changed that to an array, and ran a battery of tests.

My Zoho Account, each line is a different config scenario.
<img width="1271" alt="Screenshot 2020-07-28 at 21 22 23" src="https://user-images.githubusercontent.com/1805603/88711410-70cb1880-d118-11ea-8034-825c4e267268.png">

### Verification Process
Edit your form and set the "Update records" option to checked.  Then do a submission with an email address you know hasnt been used.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues
#11 

### Changelog Entry
- [#11](https://github.com/lightspeeddevelopment/cf-zoho/issues/11) Changed the "duplicate email" field to an array instead of a string.
